### PR TITLE
Force MotorImageryDataset class to 21 channels for bci2a dataset to work with pretrained model

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -65,7 +65,6 @@
         "48",
         "--tuh_eeg",
         "--verbose",
-        "--parallel"
       ]
     },
     {
@@ -177,7 +176,8 @@
         "--training-style=CSM_causal",
         "--embedding-dim=1024",
         "--train-data-path=data/npy_tuh_eeg",
-        "--verbose=True"
+        "--verbose=True",
+        "--dst-data-channel-count=21"
       ],
       "console": "integratedTerminal"
     },
@@ -220,9 +220,9 @@
         "--per-device-training-batch-size=32",
         "--per-device-validation-batch-size=32",
         "--num-workers=24",
-        "--num_chunks=32",
+        "--num_chunks=2",
         "--chunk_len=500",
-        "--chunk_ovlp=50",
+        "--chunk_ovlp=0",
         "--num-hidden-layers=6",
         "--num-encoder-layers=6",
         "--run-name=decoder_bci2a_32clen2_embed1024",
@@ -230,12 +230,13 @@
         "--use-encoder=True",
         "--training-style=decoding",
         "--num-decoding-classes=4",
-        // "--ft-only-encoder=True",
         "--embedding-dim=1024",
         "--train-data-path=data/npy_tuh_eeg",
         "--dst-data-path=data/bciiv2a_eeg_npz",
-        "--dst-data-channel-count=22",
-        "--verbose=True"
+        "--dst-data-channel-count=21",
+        "--verbose=True",
+        "--pretrained-model=results/models/upstream/32clen2_embed1024/model_final/model.safetensors",
+        "--ft-only-encoder=True"
       ],
       "console": "integratedTerminal"
     },

--- a/scripts/finetune.sh
+++ b/scripts/finetune.sh
@@ -2,8 +2,8 @@ python3 src/train_gpt.py \
      --training-style='decoding' \
      --num-decoding-classes=4 \
      --training-steps=10000  \
-     --eval_every_n_steps=500 \
-     --log-every-n-steps=1000 \
+     --eval_every_n_steps=100 \
+     --log-every-n-steps=100 \
      --num_chunks=2 \
      --per-device-training-batch-size=32 \
      --per-device-validation-batch-size=32 \
@@ -16,7 +16,8 @@ python3 src/train_gpt.py \
      --learning-rate=1e-4 \
      --use-encoder='True' \
      --embedding-dim=1024  \
-    #  --pretrained-model='results/models/upstream/32clen2_embed1024/model_final/model.safetensors' \
+     --pretrained-model="results/models/upstream/32clen2_embed1024/model_final/model.safetensors" \
      --dst-data-path="data/bciiv2a_eeg_npz" \
-     --dst-data-channel-count=22
-    #  --ft-only-encoder='True'
+     --dst-data-channel-count=21 \
+     --ft-only-encoder='True' \
+     --num-workers=24

--- a/src/batcher/downstream_dataset.py
+++ b/src/batcher/downstream_dataset.py
@@ -19,7 +19,7 @@ class MotorImageryDataset(EEGDataset):
         self.labels_string2int = {'left': 0, 'right': 1,
                          'foot': 2, 'tongue':3 } #, 'unknown': -1
         self.Fs = 250  # 250Hz from original paper
-        # TODO: renable? self.P = np.load("tMatrix_value.npy")
+        self.P = np.load("inputs/tMatrix_value.npy")
 
         self.trials, self.labels, self.num_trials_per_sub = self.get_trials_all()
         # keys of data ['s', 'etyp', 'epos', 'edur', 'artifacts']
@@ -87,6 +87,10 @@ class MotorImageryDataset(EEGDataset):
             if len(labels) == 0:
                 continue
 
+            for i, trial in enumerate(trials):
+                if trial.shape[0] > 21:
+                    trials[i] = trial[:21, :]
+        
             total_num.append(len(trials))
             trials_all.append(np.array(trials))
             labels_all.append(np.array(labels))

--- a/src/model.py
+++ b/src/model.py
@@ -189,7 +189,7 @@ class Model(torch.nn.Module):
             if prep_batch is True)
         """
         
-        # print(f"Initial input shape: {batch['inputs'].shape}") 
+        # print(f"Initial input shape before forward pass: {batch['inputs'].shape}") 
 
         if self.encoder is not None:
             #before prep_batch masking and things, we need to first let the splitted chunks of raw input through the encoder

--- a/src/train_gpt.py
+++ b/src/train_gpt.py
@@ -340,7 +340,8 @@ def make_model(model_config: Dict = None):
 
     else:
         encoder = None
-        model_config["parcellation_dim"] = model_config["chunk_len"] * 22
+        
+        model_config["parcellation_dim"] = model_config["chunk_len"] * model_config["dst_data_channel_count"]
 
     embedder = make_embedder(
         training_style=model_config["training_style"],
@@ -393,7 +394,10 @@ def make_model(model_config: Dict = None):
 
     if model_config["pretrained_model"] is not None:
         state_dict = load_file(model_config["pretrained_model"])
-        model.load_state_dict(state_dict)
+        # Check for missing keys
+        missing_keys = set(model.state_dict().keys()) - set(state_dict.keys())
+        print("Missing keys in state_dict:", missing_keys)
+        model.load_state_dict(state_dict, strict=False)  # Use strict=False to ignore missing
 
     if model_config["freeze_embedder"]:
         for param in model.embedder.parameters():


### PR DESCRIPTION
Made these changes to get fine tuning with pre-trained model #6 to work.

- [Pretrained model](https://github.com/neurosity/EEG-GPT/releases/tag/v0.1.0-pre) - TUH Dataset, 21 channels
- Downstream task - BCI 2a dataset, (originally 22 channels, last channel trimmed to match pretrained model)

The main takeaway is that:
- the number of channels in pretraining has to match,
- the number of channels in the dataset for `trainingStyle=decoding`.

To test this, ensure you have the datasets, pretrained model downloaded and run

`./scripts/finetune.sh`

(screenshot from wandb logs)
<img width="1637" alt="Screenshot 2024-07-12 at 12 44 09 PM" src="https://github.com/user-attachments/assets/ad99cc12-f442-4e6b-9916-88b67fda867f">

